### PR TITLE
Add touch screen support

### DIFF
--- a/Mix-match/game.js
+++ b/Mix-match/game.js
@@ -151,10 +151,17 @@ function ready() {
             overlay.classList.remove('visible');
             game.startGame();
         });
+        overlay.addEventListener('touchstart', () => {
+            overlay.classList.remove('visible');
+            game.startGame();
+        });
     });
 
     cards.forEach(card => {
         card.addEventListener('click', () => {
+            game.flipCard(card);
+        });
+        card.addEventListener('touchstart', () => {
             game.flipCard(card);
         });
     });

--- a/Snakie/index.html
+++ b/Snakie/index.html
@@ -27,6 +27,12 @@
             <div class="food" id="ah"></div>
             <div id="first" class="snake"></div>
         </div>
+        <div class="touch_controls">
+            <div class="move_up">⇧</div>
+            <div class="move_left">⇦</div>
+            <div class="move_right">⇨</div>
+            <div class="move_down">⇩</div>
+        </div>
     </div>
 </body>
 </html>

--- a/Snakie/index.html
+++ b/Snakie/index.html
@@ -11,7 +11,6 @@
 </head>
 <body>
     <div id="upperground">
-        <div id="message">Sorry, not availabe for touch devices</div>
         <div id="ground">
             <div id="gameover">
                 <h1>GAME OVER</h1>

--- a/Snakie/script.js
+++ b/Snakie/script.js
@@ -26,10 +26,6 @@ $(function(){
     var corx = []
     var cory = []
 
-    //setting up the time position
-    var w = time.width()
-    time1.style.left = `${(Swidth/2) - (w/2)}px`
-    
     // setting up the score
     scoreel.text("Score: 0")
     

--- a/Snakie/script.js
+++ b/Snakie/script.js
@@ -258,4 +258,21 @@ $(function(){
     $(document).on("keydown", function(e){
         turning(e);
     })
+
+    if ('ontouchstart' in window) {
+        $('.move_up').on('touchstart', function () {
+            turning({which: 38});
+        });
+        $('.move_down').on('touchstart', function () {
+            turning({which: 40});
+        });
+        $('.move_left').on('touchstart', function () {
+            turning({which: 37});
+        });
+        $('.move_right').on('touchstart', function () {
+            turning({which: 39});
+        });
+    } else {
+        $('.touch_controls').hide();
+    }
 })

--- a/Snakie/styles.css
+++ b/Snakie/styles.css
@@ -27,10 +27,6 @@ body {
     color: white;
 }
 
-#message{
-    display: none;
-}
-
 #upperground {
     width: 100vw;
     height: 100vh;
@@ -153,20 +149,4 @@ button {
     box-shadow: 0px 0px 5px 5px rgb(48, 46, 46);
 }
 
-
-@media only screen and (max-width : 768px) {
-    #message{
-        display: block;
-        font-size: 30px;
-        color: red;
-    }
-
-    #upperground{
-        align-items: center;
-        background-color: black;
-    }
-
-    #ground{
-        display: none;
-    }
 }

--- a/Snakie/styles.css
+++ b/Snakie/styles.css
@@ -149,4 +149,35 @@ button {
     box-shadow: 0px 0px 5px 5px rgb(48, 46, 46);
 }
 
+.touch_controls {
+    position: absolute;
+    display: grid;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}
+.touch_controls div {
+    border: 2px solid rgb(100, 21, 61);
+    color: rgb(177, 223, 13);
+    width: 75px;
+    height: 75px;
+    text-align: center;
+    font-size: 50px;
+    opacity: 0.6;
+}
+.touch_controls .move_up {
+    grid-column: 2;
+    grid-row: 1;
+}
+.touch_controls .move_down {
+    grid-column: 2;
+    grid-row: 3;
+}
+.touch_controls .move_left {
+    grid-column: 1;
+    grid-row: 2;
+}
+.touch_controls .move_right {
+    grid-column: 3;
+    grid-row: 2;
 }

--- a/Snakie/styles.css
+++ b/Snakie/styles.css
@@ -99,8 +99,8 @@ body {
 #time {
     padding: 0px 5px 0 5px;
     min-width: 150px;
-    left: 47%;
 }
+
 select {
     font-size: 16px;
     background-color: rgb(131, 87, 87);

--- a/Snakie/styles.css
+++ b/Snakie/styles.css
@@ -76,7 +76,7 @@ body {
     justify-content: center;
     align-items: center;
     font-size: 18px;
-    width: 150px;
+    width: 200px;
     background-color: rgb(44, 23, 58);
     color: rgb(177, 223, 13);
     opacity: 0.6;

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
         <p>Choose any minigame from the list, so many games to choose from, so get set play...</p>
     </div>
     <div id="gamelist">
-        <div id="row1" class="rows">
+        <div class="rows">
             <div class="segment">
                 <a href="./Snakie/index.html"><img src="./Snakie/assets/icon.png" alt="Snake Game" class="button"></a>
                 <p>Feed the snake!</p>
@@ -38,8 +38,6 @@
                 <a href="./GuessTheNumber/index.html"><img src="./GuessTheNumber/assets/icon.png" alt="Mix Match" class="button"></a>
                 <p>Guess The Number</p>
             </div>
-        </div>
-        <div id="row1" class="rows">
             <div class="segment">
                 <a href="./GuessTheNumber/index.html"><img src="./GuessTheNumber/assets/icon.png" alt="guessTheNumber" class="button"></a>
                 <p>Guess The Number</p>
@@ -60,8 +58,6 @@
                 <a href="./GuessTheNumber/index.html"><img src="./GuessTheNumber/assets/icon.png" alt="guessTheNumber" class="button"></a>
                 <p>Guess The Number</p>
             </div>
-        </div>
-        <div id="row1" class="rows">
             <div class="segment">
                 <a href="./GuessTheNumber/index.html"><img src="./GuessTheNumber/assets/icon.png" alt="guessTheNumber" class="button"></a>
                 <p>Guess The Number</p>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@
     <link rel="icon" href="./images/game-console.png">
 </head>
 <body>
-    <div id="tsnote"><p>Sorry, Not available for Touch Screen Devices right Now, touch screen support coming soon...</p></div>
     <div id="header">
         <h1>List Of Games</h1>
         <p>Choose any minigame from the list, so many games to choose from, so get set play...</p>

--- a/style.css
+++ b/style.css
@@ -26,6 +26,7 @@ body{
 
 .rows{
     display: flex;
+    flex-wrap: wrap;
     justify-content: space-around;
     margin-top: 30px;
     margin-bottom: 30px;
@@ -33,6 +34,7 @@ body{
 
 .segment{
     display: flex;
+    flex-basis: 20%;
     flex-direction: column;
     justify-content: center;
     align-items: center;

--- a/style.css
+++ b/style.css
@@ -10,13 +10,6 @@ body{
     background-size: auto;
 }
 
-#tsnote{
-    color: red;
-    font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
-    font-weight: bold;
-    display: none;
-}
-
 #header{
     text-align: center;
     color: white;
@@ -121,25 +114,3 @@ h1{
     color: black;
     font-family: 'Ubuntu', sans-serif;
   }
-
-
-@media screen and (max-width: 769px){
-    #header{
-        display: none;
-    }
-    #gamelist{
-        display: none;
-    }
-    body{
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        height: 100vh;
-    }
-    #tsnote{
-        display: inherit;
-    }
-    footer{
-        display: none;
-    }
-}


### PR DESCRIPTION
I found this repo due to the hacktoberfest label and thought I'd tackle this issue :)

Closes https://github.com/SiddharthaBhattacharjee/TimePassGames/issues/12

![grafik](https://user-images.githubusercontent.com/16883833/194712665-ae5a8604-84a4-4e76-a9bf-ba6684f0d51e.png)
I decided to place the touch controls at the middle of the screen as this works good in either orientation, portrait or horizontal. They won't be shown if the device doesn't support touch.
Feel free to suggest a different placement/size if you have other a different opinion.

Since this alone is not very useful as the main page also says that touch isn't supported, I also removed that message and checked if the remaining games are playable on my smartphone and noticed that most of them already did and for Mix-match it was also easy to add touch support as it was only about starting the game, the rest already worked.

I then also adjusted the main page to use flexbox for aligning the games so the list is usable on mobile, too, as the list was overflowing to the left and right on my mobile and I couldn't see all games.

So at the end I can now open the main page on my smartphone and I was able to play all the games with touch input.

I enabled github pages on my branch, so you can see the changes at work here: https://burned42.github.io/TimePassGames/